### PR TITLE
Configure Dependabot for pip in Wanderly directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/Wanderly" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
Updated Dependabot configuration to use pip and specified directory.