### PR TITLE
Update pylint config in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         run: | 
           pylint --load-plugins pylint_django . \
+              --disable=wrong-import-position,pointless-string-statement \
               --ignore=tests,tools \
               --ignore-patterns="__init__\.py|asgi\.py|manage\.py|settings\.py|conftest\.py" \
               | tee pylint-report.txt


### PR DESCRIPTION
Added 'wrong-import-position' and 'pointless-string-statement' to the list of disabled pylint checks in the CI workflow to reduce unnecessary linting errors.